### PR TITLE
fix: overflowing screens e verificação de nome

### DIFF
--- a/lib/components/body.dart
+++ b/lib/components/body.dart
@@ -38,7 +38,7 @@ class Body extends StatelessWidget {
                     () => Text.rich(
                       TextSpan(
                         text:
-                            "Pergunta número ${questionController.questionNumber.value}",
+                            "Pergunta número ${questionController.questionNumber.value} de ${questionController.questions.length}",
                         style: kDefaultQuestion,
                       ),
                     ),

--- a/lib/components/buttons.dart
+++ b/lib/components/buttons.dart
@@ -14,14 +14,20 @@ class ButtonStart extends StatelessWidget {
 
     return InkWell(
       onTap: () => {
-        if (userController.user.name != "")
-          {Get.to(() => const InitialScreen())}
-        else
+        if (userController.user.name.trimRight() != userController.user.name)
           {
             ErrorAlert.alertSound(context),
             ErrorAlert.alert(
-                context, "Nome inválido", "Por favor, insira um nome válido")
+                context, "Nome com espaço.", "Por favor, insira um nome válido")
           }
+        else if (userController.user.name == '')
+          {
+            ErrorAlert.alertSound(context),
+            ErrorAlert.alert(
+                context, "Nome vazio.", "Por favor, insira um nome válido")
+          }
+        else
+          {Get.to(() => InitialScreen())}
       },
       child: Container(
         width: double.infinity,

--- a/lib/components/themes.dart
+++ b/lib/components/themes.dart
@@ -59,7 +59,7 @@ class ThemeBody extends StatelessWidget {
                                     themes[index].theme, userController);
                               },
                               text: themes[index].theme),
-                          SizedBox(height: Get.height * 0.05),
+                          SizedBox(height: Get.height * 0.03),
                         ],
                       );
                     },

--- a/lib/views/initial_screen.dart
+++ b/lib/views/initial_screen.dart
@@ -9,66 +9,76 @@ import 'package:quizzle/views/themes_screen.dart';
 import '../components/initial_buttons.dart';
 
 class InitialScreen extends StatelessWidget {
-  const InitialScreen({super.key});
+  const InitialScreen({Key? key});
 
   @override
   Widget build(BuildContext context) {
     final userController = Get.find<UserController>();
 
     return Scaffold(
-      backgroundColor: bgColorBlue,
       body: Container(
-        decoration: const BoxDecoration(
+        height: double.infinity,
+        decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [bgColorBlue, lightBlue, lightGreen],
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
           ),
         ),
-        child: Stack(
-          children: [
-            Positioned(
-              top: Get.width * 0.3,
-              left: Get.width * 0.3,
-              child: Image.asset(
-                "assets/images/logo.png",
-                width: Get.width * 0.4,
+        child: SingleChildScrollView(
+          child: Stack(
+            children: [
+              Positioned(
+                top: Get.width * 0.3,
+                left: Get.width * 0.3,
+                child: Image.asset(
+                  "assets/images/logo.png",
+                  width: Get.width * 0.4,
+                ),
               ),
-            ),
-            SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 40),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(height: Get.height * 0.4), //2/6
-                    ButtonPrimary(
+              SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 40),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(height: Get.height * 0.33),
+                      ButtonPrimary(
                         onPress: () {
                           GameController.initGame(
-                              'tDgUUnib7rNwV4Kedj3L', 'geral', userController);
+                            'tDgUUnib7rNwV4Kedj3L',
+                            'geral',
+                            userController,
+                          );
                         },
-                        text: "Jogo Geral"),
-                    SizedBox(height: Get.height * 0.05),
-                    const InitialButton(
-                      pageToGo: ThemesScreen(),
-                      text: 'Temas',
-                    ),
-                    SizedBox(height: Get.height * 0.05),
-                    ButtonPrimary(
+                        text: "Jogo Geral",
+                      ),
+                      SizedBox(height: Get.height * 0.04),
+                      const InitialButton(
+                        pageToGo: ThemesScreen(),
+                        text: 'Temas',
+                      ),
+                      SizedBox(height: Get.height * 0.04),
+                      ButtonPrimary(
                         onPress: () {
                           userController.getScores();
                         },
-                        text: "Minhas Pontuações"),
-                    SizedBox(height: Get.height * 0.05),
-                    const InitialButton(
-                      pageToGo: RankingSelectScreen(),
-                      text: 'Ranking',
-                    ),
-                  ],
+                        text: "Minhas Pontuações",
+                      ),
+                      SizedBox(height: Get.height * 0.04),
+                      const InitialButton(
+                        pageToGo: RankingSelectScreen(),
+                        text: 'Ranking',
+                      ),
+                      SizedBox(
+                          height:
+                              30), // Adicione um espaço extra no final, se necessário
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/views/welcome_screen.dart
+++ b/lib/views/welcome_screen.dart
@@ -8,7 +8,7 @@ import 'package:quizzle/controllers/themes_controller.dart';
 import '../components/buttons.dart';
 
 class WelcomeScreen extends StatelessWidget {
-  const WelcomeScreen({super.key});
+  const WelcomeScreen({Key? key});
 
   @override
   Widget build(BuildContext context) {
@@ -16,54 +16,62 @@ class WelcomeScreen extends StatelessWidget {
     Get.put(UserController());
 
     return Scaffold(
-      backgroundColor: bgColorBlue,
       body: Container(
-        decoration: const BoxDecoration(
+        height: double.infinity,
+        decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [bgColorBlue, lightBlue, lightGreen],
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
           ),
         ),
-        child: Stack(
-          children: [
-            Positioned(
-              top: Get.width * 0.3,
-              left: Get.width * 0.3,
-              child: Image.asset(
-                "assets/images/logo.png",
-                width: Get.width * 0.4,
-              ),
-            ),
-            SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(height: Get.height * 0.3), //2/6
-                    const Text(
-                      "Bora começar o quiz?",
-                      style: TextStyle(
-                          color: whiteColor,
-                          fontSize: kDefaultTitle,
-                          fontWeight: FontWeight.bold),
-                    ),
-                    const Text("Insira seu nome abaixo",
-                        style: TextStyle(color: whiteColor)),
-                    const SizedBox(height: 30),
-                    const InputName(
-                      hintText: "nome",
-                    ),
-                    const SizedBox(height: 60), // 1/6
-                    const ButtonStart(), // it will take 2/6 spaces
-                    const SizedBox(height: 10), // 1/6
-                    const ButtonLogin(),
-                  ],
+        child: SingleChildScrollView(
+          child: Stack(
+            children: [
+              Positioned(
+                top: Get.width * 0.3,
+                left: Get.width * 0.3,
+                child: Image.asset(
+                  "assets/images/logo.png",
+                  width: Get.width * 0.4,
                 ),
               ),
-            ),
-          ],
+              SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(height: Get.height * 0.3),
+                      const Text(
+                        "Bora começar o quiz?",
+                        style: TextStyle(
+                          color: whiteColor,
+                          fontSize: kDefaultTitle,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const Text(
+                        "Insira seu nome abaixo",
+                        style: TextStyle(color: whiteColor),
+                      ),
+                      const SizedBox(height: 30),
+                      const InputName(
+                        hintText: "nome",
+                      ),
+                      const SizedBox(height: 60),
+                      const ButtonStart(),
+                      const SizedBox(height: 10),
+                      const ButtonLogin(),
+                      const SizedBox(
+                          height:
+                              30), // Adicione um espaço extra no final, se necessário
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Havia um erro de overflowing na tela principal, quando se abria o teclado uma faixa amarela representava o erro. Foi consertado também na tela das opções, pois ao fazer a transição pra essa tela o overflowing também aparecia. Foi inserido no botão de início uma verificação para caso o nome tenha um espaço a mais na frente para apresentar um erro, e também caso o nome seja nada.